### PR TITLE
feat: added log middleware

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -6,6 +6,7 @@ import (
 	"PattyWagon/internal/repository"
 	"PattyWagon/internal/service"
 	"PattyWagon/internal/storage"
+	"PattyWagon/logger"
 	"PattyWagon/observability"
 	"context"
 	"fmt"
@@ -44,6 +45,9 @@ func gracefulShutdown(apiServer *http.Server, done chan bool) {
 }
 
 func main() {
+	// Init logger
+	logger.Init()
+
 	db := database.New()
 	defer db.Close()
 	repo := repository.New(db)

--- a/internal/server/file_upload_handler.go
+++ b/internal/server/file_upload_handler.go
@@ -4,7 +4,6 @@ import (
 	"PattyWagon/internal/constants"
 	"PattyWagon/observability"
 	"fmt"
-	"log"
 	"net/http"
 	"strconv"
 )
@@ -19,7 +18,6 @@ func (s *Server) fileUploadHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := r.ParseMultipartForm(150 << 10); err != nil { // 150 KB
-		log.Printf("error parsing multipart form: %v", err)
 		sendErrorResponse(w, http.StatusInternalServerError, fmt.Sprintf("error parsing multipart form: %v", err))
 		return
 	}

--- a/internal/server/file_upload_handler.go
+++ b/internal/server/file_upload_handler.go
@@ -26,7 +26,6 @@ func (s *Server) fileUploadHandler(w http.ResponseWriter, r *http.Request) {
 
 	file, header, err := r.FormFile("file")
 	if err != nil {
-		log.Printf("invalid request: %v", err)
 		sendErrorResponse(w, http.StatusBadRequest, "invalid request")
 		return
 	}
@@ -36,13 +35,10 @@ func (s *Server) fileUploadHandler(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		switch err {
 		case constants.ErrMaximumFileSize:
-			log.Println("invalid file size")
 			sendErrorResponse(w, http.StatusBadRequest, err.Error())
 		case constants.ErrInvalidFileType:
-			log.Println("invalid file type")
 			sendErrorResponse(w, http.StatusBadRequest, err.Error())
 		default:
-			log.Printf("internal server error: %v", err)
 			sendErrorResponse(w, http.StatusInternalServerError, err.Error())
 		}
 		return

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"PattyWagon/logger"
 	"net/http"
 )
 
@@ -13,5 +14,5 @@ func (s *Server) RegisterRoutes() http.Handler {
 	mux.HandleFunc("POST /v1/login/email", s.emailLoginHandler)
 	mux.HandleFunc("POST /v1/file", s.fileUploadHandler)
 
-	return s.contentMiddleware(s.authMiddleware(mux))
+	return logger.LoggingMiddleware(s.contentMiddleware(s.authMiddleware(mux)))
 }

--- a/internal/service/file_upload.go
+++ b/internal/service/file_upload.go
@@ -5,11 +5,11 @@ import (
 	"PattyWagon/internal/model"
 	"PattyWagon/internal/storage"
 	"PattyWagon/internal/utils"
+	"PattyWagon/logger"
 	"PattyWagon/observability"
 	"context"
 	"fmt"
 	"io"
-	"log"
 	"os"
 	"path/filepath"
 
@@ -19,6 +19,8 @@ import (
 func (s *Service) UploadFile(ctx context.Context, file io.Reader, filename string, sizeInBytes int64) (model.File, error) {
 	ctx, span := observability.Tracer.Start(ctx, "service.file_upload")
 	defer span.End()
+
+	log := logger.GetLoggerFromContext(ctx)
 
 	var result model.File
 

--- a/logger/response_writer.go
+++ b/logger/response_writer.go
@@ -1,0 +1,23 @@
+package logger
+
+import "net/http"
+
+type responseWriter struct {
+	http.ResponseWriter
+	statusCode int
+	body       []byte
+}
+
+type ErrorResponse struct {
+	Error string `json:"error,omitempty"`
+}
+
+func (rw *responseWriter) WriteHeader(code int) {
+	rw.statusCode = code
+	rw.ResponseWriter.WriteHeader(code)
+}
+
+func (rw *responseWriter) Write(b []byte) (int, error) {
+	rw.body = append(rw.body, b...)
+	return rw.ResponseWriter.Write(b)
+}

--- a/logger/zerolog.go
+++ b/logger/zerolog.go
@@ -55,6 +55,6 @@ func LoggingMiddleware(next http.Handler) http.Handler {
 	})
 }
 
-func GetLogger(ctx context.Context) *zerolog.Logger {
+func GetLoggerFromContext(ctx context.Context) *zerolog.Logger {
 	return &log.Logger
 }

--- a/logger/zerolog.go
+++ b/logger/zerolog.go
@@ -1,0 +1,54 @@
+package logger
+
+import (
+	"encoding/json"
+	"net/http"
+	"os"
+
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+)
+
+func Init() {
+	if os.Getenv("ENV") == "production" {
+		zerolog.SetGlobalLevel(zerolog.InfoLevel)
+	} else {
+		log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stderr})
+
+		zerolog.SetGlobalLevel(zerolog.DebugLevel)
+	}
+}
+
+func LoggingMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Log incoming request
+		log.Info().
+			Str("method", r.Method).
+			Str("path", r.URL.Path).
+			Msg("Request started")
+
+		// Process next request
+		wrapped := &responseWriter{ResponseWriter: w, statusCode: 200}
+		next.ServeHTTP(wrapped, r.WithContext(r.Context()))
+
+		// Log request completion
+		logEvent := log.Info()
+		if wrapped.statusCode >= 400 {
+			logEvent = log.Error()
+		}
+
+		logEvent.Str("method", r.Method).
+			Str("path", r.URL.Path).
+			Int("status", wrapped.statusCode)
+
+		if wrapped.statusCode >= 400 && len(wrapped.body) > 0 {
+			var errResp ErrorResponse
+
+			if err := json.Unmarshal(wrapped.body, &errResp); err != nil {
+				logEvent = logEvent.Str("error", errResp.Error)
+			}
+		}
+
+		logEvent.Msg("Request completed")
+	})
+}

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,25 @@
+export GOOSE_DRIVER=postgres
+export GOOSE_MIGRATION_DIR=db/sql/migrations
+export GOOSE_DBSTRING="user=postgres password=postgres dbname=patty-wagon-dev host=localhost port=5432 sslmode=disable"
+
+export PORT=8080
+export APP_ENV=local
+export DB_HOST=localhost
+export DB_PORT=5432
+export DB_DATABASE=patty-wagon-dev
+export DB_USERNAME=postgres
+export DB_PASSWORD=postgres
+export DB_SCHEMA=public
+
+export JWT_SIGNATURE_KEY=solidteam
+
+export S3_ACCESS_KEY_ID=team-solid
+export S3_SECRET_ACCESS_KEY=@team-solid
+export S3_ENDPOINT=localhost:9000
+export S3_BUCKET=images
+export S3_MAX_CONCURRENT_UPLOAD=5
+
+# Image Compression
+export MAX_CONCURRENT_COMPRESS=10
+
+export OTLP_ENDPOINT=localhost:4317


### PR DESCRIPTION
**WHY**
- Biar logging konsisten dan rapi soalnya di project sebelumnya aga bingung ngetrace lognya

**HOW**
- logging pakai zerolog
- implement logging middleware jadi kalau sendErrorResponse udah ke-log juga err messagenya
- masih bisa pakai log.Printf (debug level) tapi ini bakal otomatis pake zerolog punya bukan log bawaan Go

```
func (s *Service) UploadFile(ctx context.Context, file io.Reader, filename string, sizeInBytes int64) (model.File, error) {
	ctx, span := observability.Tracer.Start(ctx, "service.file_upload")
	defer span.End()

	log := logger.GetLoggerFromContext(ctx)      <---- Add this to Your functions
	
	(rest of code ...)

```

**Result**
<img width="1130" height="64" alt="image" src="https://github.com/user-attachments/assets/c80a6314-69af-4c73-8e1c-697549b63ee3" />
